### PR TITLE
#161863657 Handle Errors Globally

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -2,6 +2,8 @@ import * as bodyParser from "body-parser";
 import * as express from "express";
 import * as mongoose from "mongoose";
 import * as morgan from "morgan";
+
+import Error from "./interfaces/error";
 import mainRoutes from "./routes/main.routes";
 
 const mongoUrl: string = process.env.MONGO_URL || "mongodb://localhost/diligentTime";
@@ -12,5 +14,10 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(morgan("dev"));
 app.use("/", mainRoutes);
+app.use((error: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  /* tslint:disable-next-line */
+  console.error(error);
+  res.status(error.statusCode || 500).json({ error: error.message });
+});
 
 export default app;

--- a/src/interfaces/error.d.ts
+++ b/src/interfaces/error.d.ts
@@ -1,0 +1,3 @@
+export default interface CustomError extends Error {
+  statusCode?: number;
+}


### PR DESCRIPTION
#### What does this PR do?
Introduces the global error handler to the application. Refactors the Todo Controller to use the global error handler instead of each function catching and handling its errors. 
#### Description of Task to be completed?
Refactor code to use the async/await model of working with promises.
Use the global error handler to handle all the errors resulting from unresolved promises.
Implement all the pending edge cases tests that needed to test promise rejection.
#### How should this be manually tested?
There are unit tests for this so you just need to run tests.
#### Any background context you want to provide?
It was a bit cumbersome to have each function have it's own catch statement dictate how the error is going to be handled. The global error handler now specifies how every error is going to be sent back to the client.
Also, a new CustomError interface had to be defined to add the `statusCode` property to the Error Object.
#### What are the relevant pivotal tracker stories?
#161863657